### PR TITLE
Importing blast.config and blast.mapmaker

### DIFF
--- a/2019_installation_notes.sh
+++ b/2019_installation_notes.sh
@@ -1218,3 +1218,61 @@ srun -A b1094 -p ciera-std -t 1:00:00 --mem=50G -N 1 -n 6 --pty bash -l
 bash-4.2$
 #but it should be the regular one. Plus, I can't access the project space or the home space
 
+#06/28/19 -Alper
+#Importing blast.config and blast.mapmaker without an error so that "toast_make_all_runs.py" 
+#could run and create an xml file correctly. I did the installation on the compute node
+#by submitting an interactive job. After the installation is completed, I logged out from
+#the interactive sessions and loaded imported the blast.config and blast.mapmaker on
+#the login node.
+
+#On the compute node (interactive session)
+
+$ cp -r * /projects/b1092/lib64/python2.7/site-packages/pyblast /projects/b1092/pyblast
+
+#Edited /projects/b1092/pyblast/setup.py to comment out line 31 (starting with git_hash = ..)
+
+$ module use /projects/b1092/modules
+$ module load python/anaconda
+$ conda create -p /projects/b1092/software/pyblast-env python=2.7
+$ source activate /projects/b1092/software/pyblast-env
+$ cd /projects/b1092/pyblast
+$ python setup.py install (this installs within pyblast-env)
+$ cp -r /projects/b1092/software/toast/lib/python2.7/site-packages/pytoast /projects/b1092/software/pyblast-env/lib/python2.7/site-packages/
+
+$ cp /projects/b1092/software/getdata/0.9.3/lib/python2.7/site-packages/pygetdata.* /projects/b1092/software/pyblast-env/lib/python2.7/site-packages/
+$ conda install numpy
+$ conda install scipy
+$ source deactivate
+
+$ logout #end interactive session and go back to login onde
+
+$ module load fftw/3.3.8 cfitsio/3.45 getdata/0.9.3 wcslib/5.15 boost/1.61.0 python/anaconda
+$ python
+#>>> import blast.config
+#>>> import blast.mapmaker
+#>>> 
+
+#On the compute node this did not work as I encountered libboost_python-mt.so.1.53.0 error. 
+#See below for error
+#I think Paul was creating a symlink for this file.
+
+#(/projects/b1092/software/pyblast-env) [egc2975@qnode8101 boost]$ python
+#Python 2.7.16 |Anaconda, Inc.| (default, Mar 14 2019, 21:00:58)
+#[GCC 7.3.0] on linux2
+#Type "help", "copyright", "credits" or "license" for more information.
+#>>> import blast.config
+#>>> import blast.mapmaker
+#Traceback (most recent call last):
+#  File "<stdin>", line 1, in <module>
+#  File "/projects/b1092/software/pyblast-env/lib/python2.7/site-packages/blast/mapmaker/__init__.py", line 11, in <module>
+#    from params import *
+#  File "/projects/b1092/software/pyblast-env/lib/python2.7/site-packages/blast/mapmaker/params.py", line 15, in <module>
+#    from pytoast.blast.runblast import ToastRunConfig
+#  File "/projects/b1092/software/pyblast-env/lib/python2.7/site-packages/pytoast/blast/runblast.py", line 11, in <module>
+#    import pytoast.core as pt
+#  File "/projects/b1092/software/pyblast-env/lib/python2.7/site-packages/pytoast/core/__init__.py", line 2, in <module>
+#    from _pytoast import *
+#ImportError: libboost_python-mt.so.1.53.0: cannot open shared object file: No such file or directory
+
+#On the login node it does not give libboost_python-mt.so.1.53.0 error.
+


### PR DESCRIPTION
Added how to import blast.config and blast.mapmaker from python interpreter without an error on the login node.